### PR TITLE
add greater than operation to PreciseIntWrapper

### DIFF
--- a/src/simulation/marginAccount.ts
+++ b/src/simulation/marginAccount.ts
@@ -116,6 +116,6 @@ export class MarginsWrapper {
   }
 
   canLiquidate(): boolean {
-    return this.totalRequiredMargin() > this.margins.availableMargin;
+    return this.totalRequiredMargin().gt(this.margins.availableMargin);
   }
 }

--- a/src/simulation/preciseMath.ts
+++ b/src/simulation/preciseMath.ts
@@ -36,6 +36,14 @@ export class PreciseIntWrapper {
     return new PreciseIntWrapper(this.val.mul(rhs.val).div(PRECISE_NUM_ONE));
   }
 
+  gt(rhs: PreciseIntWrapper): boolean {
+    return this.val.gt(rhs.val);
+  }
+
+  lt(rhs: PreciseIntWrapper): boolean {
+    return this.val.lt(rhs.val);
+  }
+
   div(rhs: PreciseIntWrapper): PreciseIntWrapper {
     return new PreciseIntWrapper(this.val.mul(PRECISE_NUM_ONE).div(rhs.val));
   }


### PR DESCRIPTION
The canLiquidate method uses > to compare PreciseIntWrappers, but always returns false.

* Add gt and lt wrappers to PreciseIntWrapper
* Use new gt wrapper method in canLiquidate