### PR TITLE
Restore correct method for parsing price from real estate market Pyth feed

### DIFF
--- a/src/simulation/marginAccount.ts
+++ b/src/simulation/marginAccount.ts
@@ -53,7 +53,7 @@ export class MarginAccountWrapper {
             price: BigInt(priceFeed.priceMessage.price.toString()),
             expo: priceFeed.priceMessage.exponent,
           }
-        : { price: BigInt(priceFeed.price!.toString()), expo: priceFeed.exponent };
+        : { price: priceFeed.aggregate.price, expo: 0 };
       const indexPrice = PreciseIntWrapper.fromDecimal(priceInfo.price, priceInfo.expo);
       const {
         initialMargin: positionInitialMargin,


### PR DESCRIPTION
The real estate market Pyth prices are returned as  a USD value with no exponent on priceFeed.aggregate.price. This interpretation for the old Pyth layout is restored to the way it was before the PythV2 layout was added.